### PR TITLE
Refactor channel schema and repository queries

### DIFF
--- a/bot/database/SCHEMA.md
+++ b/bot/database/SCHEMA.md
@@ -1,0 +1,16 @@
+# Database Schema
+
+## channels
+
+The `channels` table stores Telegram channels linked to users.
+
+| Column     | Type      | Constraints / Notes                        |
+|------------|-----------|---------------------------------------------|
+| id         | BIGINT    | Primary key (Telegram channel ID)          |
+| user_id    | BIGINT    | References `users.id`; owner of the channel |
+| title      | VARCHAR(255) | Human‑readable channel title                |
+| username   | VARCHAR(255) | Optional public @username; unique          |
+| created_at | TIMESTAMPTZ | Timestamp of creation (defaults to `now()`) |
+
+These names are canonical and should be used consistently across
+models, repositories, and queries.

--- a/bot/database/repositories/channel_repository.py
+++ b/bot/database/repositories/channel_repository.py
@@ -5,39 +5,57 @@ class ChannelRepository:
     def __init__(self, pool: asyncpg.Pool):
         self.pool = pool
 
-    # --- UPDATED METHOD ---
-    async def create_channel(self, channel_id: int, admin_id: int, channel_name: str):
-        """Adds a new channel to the database for a specific admin."""
+    async def create_channel(
+        self, channel_id: int, user_id: int, title: str, username: str | None = None
+    ) -> None:
+        """Adds a new channel to the database for a specific user.
+
+        If the channel already exists, its title and username are refreshed.
+        """
+
         async with self.pool.acquire() as conn:
             await conn.execute(
                 """
-                INSERT INTO channels (channel_id, admin_id, channel_name)
-                VALUES ($1, $2, $3)
-                ON CONFLICT (channel_id) DO UPDATE SET channel_name = EXCLUDED.channel_name
+                INSERT INTO channels (id, user_id, title, username)
+                VALUES ($1, $2, $3, $4)
+                ON CONFLICT (id) DO UPDATE
+                    SET title = EXCLUDED.title,
+                        username = EXCLUDED.username
                 """,
-                channel_id, admin_id, channel_name
+                channel_id,
+                user_id,
+                title,
+                username,
             )
 
     async def get_channel_by_id(self, channel_id: int) -> Optional[Dict[str, Any]]:
-        """Retrieves a single channel by its ID."""
+        """Retrieve a single channel by its ID."""
+
         async with self.pool.acquire() as conn:
-            record = await conn.fetchrow("SELECT * FROM channels WHERE channel_id = $1", channel_id)
+            record = await conn.fetchrow("SELECT * FROM channels WHERE id = $1", channel_id)
             return dict(record) if record else None
 
     async def count_user_channels(self, user_id: int) -> int:
-        """Counts how many channels a user has registered."""
+        """Count how many channels a user has registered."""
+
         async with self.pool.acquire() as conn:
-            return await conn.fetchval("SELECT COUNT(*) FROM channels WHERE admin_id = $1", user_id)
-            
-    # --- NEW METHOD TO GET ALL CHANNELS ---
+            return await conn.fetchval(
+                "SELECT COUNT(*) FROM channels WHERE user_id = $1", user_id
+            )
+
     async def get_user_channels(self, user_id: int) -> List[Dict[str, Any]]:
-        """Retrieves all channels registered by a user."""
+        """Retrieve all channels registered by a user."""
+
         async with self.pool.acquire() as conn:
-            records = await conn.fetch("SELECT channel_id, channel_name FROM channels WHERE admin_id = $1", user_id)
+            records = await conn.fetch(
+                "SELECT id, title, username FROM channels WHERE user_id = $1",
+                user_id,
+            )
             return [dict(record) for record in records]
 
     async def delete_channel(self, channel_id: int) -> bool:
-        """Deletes a channel by its ID."""
+        """Delete a channel by its ID."""
+
         async with self.pool.acquire() as conn:
-            result = await conn.execute("DELETE FROM channels WHERE channel_id = $1", channel_id)
-            return result != 'DELETE 0'
+            result = await conn.execute("DELETE FROM channels WHERE id = $1", channel_id)
+            return result != "DELETE 0"

--- a/bot/handlers/admin_handlers.py
+++ b/bot/handlers/admin_handlers.py
@@ -32,7 +32,7 @@ async def get_and_verify_channel(
         await message.reply(i18n.get("guard-channel-not-registered"))
         return None
 
-    if db_channel['admin_id'] != message.from_user.id:
+    if db_channel["user_id"] != message.from_user.id:
         await message.reply(i18n.get("guard-channel-not-owner"))
         return None
     
@@ -55,14 +55,16 @@ async def add_channel_handler(
     except Exception:
         return await message.reply(i18n.get("add-channel-not-found", channel_name=channel_username))
     
-    # --- UPDATED LINE ---
-    # Now we pass the channel name (title) to the repository method
+    # Store basic channel information in the database
     await channel_repo.create_channel(
-        channel_id=channel.id, 
-        admin_id=message.from_user.id,
-        channel_name=channel.title # <-- PASSING THE NAME
+        channel_id=channel.id,
+        user_id=message.from_user.id,
+        title=channel.title,
+        username=channel.username,
     )
-    await message.reply(i18n.get("add-channel-success", channel_title=channel.title, channel_id=channel.id))
+    await message.reply(
+        i18n.get("add-channel-success", channel_title=channel.title, channel_id=channel.id)
+    )
 
 
 # --- GUARD MODULE ---

--- a/bot/models/twa.py
+++ b/bot/models/twa.py
@@ -56,7 +56,8 @@ class Channel(BaseModel):
     """Representation of a Telegram channel in API responses."""
 
     id: int
-    channel_name: str
+    title: str
+    username: Optional[str] = None
 
 
 class ScheduledPost(BaseModel):


### PR DESCRIPTION
## Summary
- standardize canonical columns for `channels` table and adjust repository queries
- update API, handlers and models to use `id`, `user_id`, `title` and `username`
- document `channels` table schema for future reference

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68997d87911c832db4338004a9ea4cf6