### PR TITLE
fix: Resolve mypy errors in dependency container

### DIFF
--- a/bot/container.py
+++ b/bot/container.py
@@ -11,14 +11,13 @@ from fluent_compiler.resource import FluentResource
 from punctuated import Singleton
 
 from bot.config import Settings
-from bot.database.db import create_async_session
+from bot.database.db import create_pool
 from bot.database.repositories.analytics_repository import AnalyticsRepository
 from bot.database.repositories.channel_repository import ChannelRepository
 from bot.database.repositories.plan_repository import PlanRepository
 from bot.database.repositories.scheduler_repository import SchedulerRepository
 from bot.database.repositories.user_repository import UserRepository
 from bot.services.analytics_service import AnalyticsService
-from bot.services.auth_service import AuthService
 from bot.services.guard_service import GuardService
 from bot.services.scheduler_service import SchedulerService
 from bot.services.subscription_service import SubscriptionService
@@ -65,7 +64,7 @@ class Container(punq.Container):
         storage=MemoryStorage(),
     )
 
-    db_session = Singleton(create_async_session, dsn=config.provided.DB_DSN)
+    db_session = Singleton(create_pool, dsn=config.provided.DB_DSN)
 
     i18n = Singleton(I18nManager, core=locales.provided.get_fluent_runtime_core())
 
@@ -75,7 +74,6 @@ class Container(punq.Container):
     scheduler_repository = Singleton(SchedulerRepository, session=db_session)
     analytics_repository = Singleton(AnalyticsRepository, session=db_session)
 
-    auth_service = Singleton(AuthService, repository=user_repository)
     guard_service = Singleton(GuardService, repository=channel_repository)
     subscription_service = Singleton(SubscriptionService, repository=channel_repository)
     scheduler_service = Singleton(

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock
 from aiogram import Bot
 from bot.services.analytics_service import AnalyticsService
 from bot.database.repositories.analytics_repository import AnalyticsRepository


### PR DESCRIPTION
This commit fixes two critical mypy errors that were preventing the application from being correctly type-checked.

1.  Corrected the database dependency in `bot/container.py`. The container was trying to import `create_async_session`, but the provider in `bot/database/db.py` is named `create_pool`. The import and the singleton definition have been updated to use the correct name.

2.  Removed the unused `AuthService` dependency from `bot/container.py`. The `AuthService` class did not exist in the specified module, and the dependency was no longer needed. The import and the singleton definition have been removed.