### PR TITLE
Fix ImportError for I18nManager

### DIFF
--- a/bot/container.py
+++ b/bot/container.py
@@ -4,7 +4,7 @@ import punq
 from aiogram import Bot, Dispatcher
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.memory import MemoryStorage
-from aiogram_i18n.middleware import I18nManager
+from aiogram_i18n.managers import I18nManager
 from aiogram_i18n.cores import FluentRuntimeCore
 from fluent_compiler.bundle import FluentBundle
 from fluent_compiler.resource import FluentResource


### PR DESCRIPTION
Updates the import path for `I18nManager` from `aiogram_i18n.middleware` to `aiogram_i18n.managers`.

This change is necessary due to an update in the `aiogram-i18n` library where the class was moved, which was causing the application to fail on startup.