### PR TITLE
fix(celery): implement async-to-sync bridge and align beat schedule

### DIFF
--- a/.github/workflows/compose-verify.yml
+++ b/.github/workflows/compose-verify.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Build & start (Compose)
         run: docker compose -f docker-compose.yml -f .github/ci.compose.override.yml up -d --build
 
+      - name: Show Celery registered tasks
+        run: |
+          set +e
+          docker compose exec -T celery_worker celery -A bot.celery_app inspect registered
+          docker compose logs --no-color --tail=120 celery_worker || true
+          docker compose logs --no-color --tail=120 celery_beat || true
+          set -e
+
       - name: Wait for API /health
         run: |
           for i in {1..60}; do


### PR DESCRIPTION
Refactors `send_post_task` to be a synchronous Celery task that wraps asynchronous logic using `asyncio.run()`. This change ensures compatibility with Celery's execution model.

Adds stub implementations for `send_scheduled_message` and `update_post_views_task` to match the tasks defined in the Celery Beat schedule, preventing `NotRegistered` errors on startup.

Adds a diagnostic step to the CI workflow to inspect registered Celery tasks and display container logs, improving visibility for debugging and verification.