### PR TITLE
refactor(db): normalize plan lookups to 'name' and keep 'plan_name' a…

### DIFF
--- a/.github/workflows/compose-verify.yml
+++ b/.github/workflows/compose-verify.yml
@@ -51,6 +51,14 @@ jobs:
           docker compose exec -T postgres psql -U analytic -d analytic_bot -c "SELECT 1 FROM scheduled_posts LIMIT 1;" || true
           docker compose exec -T postgres psql -U analytic -d analytic_bot -c "SELECT 1 FROM sent_posts LIMIT 1;" || true
 
+      - name: Verify PlanRepository queries (smoke)
+        run: |
+          set -e
+          # SELECT by name ishlashi kerak
+          docker compose exec -T postgres psql -U analytic -d analytic_bot -c "SELECT id,name,max_channels,max_posts_per_month FROM plans WHERE name='free' LIMIT 1;"
+          # Alias plan_name mavjud (SELECT ... name AS plan_name)
+          docker compose exec -T postgres psql -U analytic -d analytic_bot -c "SELECT name AS plan_name FROM plans LIMIT 1;"
+
       - name: Show Celery registered tasks
         run: |
           set +e

--- a/bot/database/repositories/plan_repository.py
+++ b/bot/database/repositories/plan_repository.py
@@ -11,5 +11,17 @@ class PlanRepository:
         """Retrieves the limits for a specific plan by its name."""
         async with self.pool.acquire() as conn:
             return await conn.fetchrow(
-                "SELECT * FROM plans WHERE plan_name = $1", plan_name
+                """
+                SELECT
+                    id,
+                    name,
+                    /* backward compatibility for callers expecting 'plan_name' */
+                    name AS plan_name,
+                    max_channels,
+                    max_posts_per_month
+                FROM plans
+                WHERE name = $1
+                LIMIT 1
+                """,
+                plan_name,
             )

--- a/bot/database/repositories/user_repository.py
+++ b/bot/database/repositories/user_repository.py
@@ -27,7 +27,7 @@ class UserRepository:
 
     async def get_user_plan_name(self, user_id: int) -> Optional[str]:
         """
-        Retrieves the name of the user's current subscription plan.
+        Retrieves the name of the user's current subscription plan. Returns plan name.
         """
         query = """
             SELECT p.name


### PR DESCRIPTION
…lias

PlanRepository now relies on plans.name; the 'name AS plan_name' alias has been left for backward compatibility; a psql smoke check has been added to the CI. The schema remains unchanged for now.