### PR TITLE
I've established a baseline for `flake8` and `mypy` and applied some …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,24 @@
+# --- runtime / bot ---
 BOT_TOKEN=replace_me
+ADMIN_IDS=8034732332,1527638770
+DEFAULT_LOCALE=en
+STORAGE_CHANNEL_ID=12345
+
+# --- postgres ---
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_USER=analytic
+POSTGRES_PASSWORD=change_me
+POSTGRES_DB=analytic_bot
+
+# --- URLs / ports ---
 DATABASE_URL=postgresql://analytic:change_me@postgres:5432/analytic_bot
 REDIS_URL=redis://redis:6379/0
 API_HOST=0.0.0.0
 API_PORT=8000
+API_HOST_URL=http://localhost:8000
+TWA_HOST_URL=http://localhost
+
+# --- feature flags / misc ---
+ENFORCE_PLAN_LIMITS=True
+SENTRY_DSN=

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,11 @@
 [flake8]
-extend-ignore = E501,W391
-exclude = .git,__pycache__,.mypy_cache,.ruff_cache,twa-frontend,node_modules
+max-line-length = 100
+extend-ignore = E203, W503
+exclude =
+    .git,
+    __pycache__,
+    .venv, venv, build, dist,
+    alembic, migrations,
+    postgres-init
+per-file-ignores =
+    __init__.py:F401

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -50,15 +50,40 @@ jobs:
               - '!**/tests/**'
               - '!**/__init__.py'
 
+      - name: Prepare .env for tests
+        run: |
+          if [ -f .env ]; then
+            echo ".env already exists"
+          elif [ -f .env.example ]; then
+            cp .env.example .env
+          else
+            cat > .env <<'EOF'
+      BOT_TOKEN=replace_me
+      ADMIN_IDS=8034732332,1527638770
+      DEFAULT_LOCALE=en
+      STORAGE_CHANNEL_ID=12345
+      POSTGRES_HOST=postgres
+      POSTGRES_PORT=5432
+      POSTGRES_USER=analytic
+      POSTGRES_PASSWORD=change_me
+      POSTGRES_DB=analytic_bot
+      DATABASE_URL=postgresql://analytic:change_me@postgres:5432/analytic_bot
+      REDIS_URL=redis://redis:6379/0
+      API_HOST=0.0.0.0
+      API_PORT=8000
+      API_HOST_URL=http://localhost:8000
+      TWA_HOST_URL=http://localhost
+      ENFORCE_PLAN_LIMITS=True
+      SENTRY_DSN=
+      EOF
+          fi
       - name: Run security check for vulnerabilities in dependencies
         run: poetry run pip-audit
 
       - name: Run static analysis with flake8
-        if: ${{ steps.filter.outputs.code == 'true' }}
-        run: poetry run flake8
+        run: poetry run flake8 .
 
       - name: Run type checking with mypy
-        if: ${{ steps.filter.outputs.code == 'true' }}
         run: poetry run mypy --install-types --non-interactive .
 
       - name: Run import sorting check with isort

--- a/bot/container.py
+++ b/bot/container.py
@@ -4,11 +4,10 @@ import punq
 from aiogram import Bot, Dispatcher
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.memory import MemoryStorage
-from aiogram_i18n.managers import I18nManager
 from aiogram_i18n.cores import FluentRuntimeCore
+from aiogram_i18n.managers import I18nManager
 from fluent_compiler.bundle import FluentBundle
 from fluent_compiler.resource import FluentResource
-from punctuated import Singleton
 
 from bot.config import Settings
 from bot.database.db import create_pool
@@ -21,6 +20,7 @@ from bot.services.analytics_service import AnalyticsService
 from bot.services.guard_service import GuardService
 from bot.services.scheduler_service import SchedulerService
 from bot.services.subscription_service import SubscriptionService
+from punctuated import Singleton
 
 
 class Locales:
@@ -37,9 +37,7 @@ class Locales:
 
             for ftl_file in (locales_path / locale.name).iterdir():
                 with open(ftl_file, "r", encoding="utf-8") as f:
-                    self.locales_map[locale.name].add_resource(
-                        FluentResource(f.read())
-                    )
+                    self.locales_map[locale.name].add_resource(FluentResource(f.read()))
 
     def get_fluent_runtime_core(self) -> FluentRuntimeCore:
         return FluentRuntimeCore(

--- a/bot/services/subscription_service.py
+++ b/bot/services/subscription_service.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from fastapi import HTTPException
 
+# Lazily resolve other repos via container to keep current DI untouched
+from bot.container import container
 from bot.database.models import SubscriptionStatus
 from bot.database.repositories import (
     ChannelRepository,
@@ -10,8 +12,6 @@ from bot.database.repositories import (
     SchedulerRepository,
     UserRepository,
 )
-# Lazily resolve other repos via container to keep current DI untouched
-from bot.container import container
 
 
 class SubscriptionService:

--- a/bot/tasks.py
+++ b/bot/tasks.py
@@ -8,7 +8,7 @@ from bot.container import container
 @celery_app.task(name="bot.tasks.send_post_task")
 def send_post_task(scheduler_id: int):
     async def _run():
-        bot = container.bot()
+        container.bot()
         try:
             scheduler_repository = container.scheduler_repository()
             scheduler = await scheduler_repository.get_scheduler_by_id(scheduler_id)

--- a/clear_webhook.py
+++ b/clear_webhook.py
@@ -1,4 +1,5 @@
 import os
+
 from bot.config import settings
 
 token = None

--- a/health_app.py
+++ b/health_app.py
@@ -1,8 +1,10 @@
 # health_app.py
-from fastapi import FastAPI
 from typing import Dict
 
+from fastapi import FastAPI
+
 app = FastAPI()
+
 
 @app.get("/health")
 def health() -> Dict[str, str]:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,23 @@
 [mypy]
+python_version = 3.11
 ignore_missing_imports = True
-follow_imports = skip
+follow_imports = silent
+namespace_packages = True
+pretty = True
+show_error_codes = True
+warn_return_any = False
+warn_unused_ignores = False
+
+# faqat asosiy kod
+files = api.py, bot
+
+# hozircha tekshirmaymiz
+exclude = (?x)(
+    ^alembic/|
+    ^postgres-init/|
+    ^tests/
+)
+
+# Lokal stub modul
+[mypy-punctuated]
+ignore_errors = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -1045,6 +1045,23 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)",
 typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
 
 [[package]]
+name = "flake8"
+version = "7.3.0"
+description = "the modular source code checker: pep8 pyflakes and co"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e"},
+    {file = "flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872"},
+]
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.14.0,<2.15.0"
+pyflakes = ">=3.4.0,<3.5.0"
+
+[[package]]
 name = "fluent-runtime"
 version = "0.4.0"
 description = "Localization library for expressive translations."
@@ -1810,6 +1827,18 @@ python-dateutil = ">=2.7"
 
 [package.extras]
 dev = ["meson-python (>=0.13.1,<0.17.0)", "pybind11 (>=2.13.2,!=2.13.3)", "setuptools (>=64)", "setuptools_scm (>=7)"]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+files = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
 
 [[package]]
 name = "mdurl"
@@ -2704,6 +2733,18 @@ files = [
 defusedxml = ">=0.7.1,<0.8.0"
 
 [[package]]
+name = "pycodestyle"
+version = "2.14.0"
+description = "Python style guide checker"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d"},
+    {file = "pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.7"
 description = "Data validation using Python type hints"
@@ -2860,6 +2901,18 @@ azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0
 gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
 toml = ["tomli (>=2.0.1)"]
 yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
+name = "pyflakes"
+version = "3.4.0"
+description = "passive checker of Python programs"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f"},
+    {file = "pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58"},
+]
 
 [[package]]
 name = "pygments"
@@ -3849,4 +3902,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "13b6a40e91fd88f9be26d5dd9fd4f3f26de2f2ae95814d820fc4e90ce49d2fd4"
+content-hash = "31c6e88a9d15795a71faa4593f8db05ebd5ac139c46fff233dd9f33ca4dd4e08"

--- a/punctuated.py
+++ b/punctuated.py
@@ -6,6 +6,7 @@ class Singleton:
         my_dep = Singleton(MyClass, arg1, kw=value)
         inst = my_dep()  # returns single instance
     """
+
     def __init__(self, cls, *args, **kwargs):
         self._cls = cls
         self._args = args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ black = "^24.4.2"
 fakeredis="^2.21.0"
 pytest-cov="^4.1.0"
 pip-audit = "^2.9.0"
+flake8 = "^7.3.0"
 
 
 [build-system]

--- a/run_bot.py
+++ b/run_bot.py
@@ -1,4 +1,5 @@
 import os
+
 from bot.config import settings
 
 token = None

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -1,8 +1,10 @@
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 from aiogram import Bot
-from bot.services.analytics_service import AnalyticsService
+
 from bot.database.repositories.analytics_repository import AnalyticsRepository
+from bot.services.analytics_service import AnalyticsService
 
 
 # Pytest bizga testlarni sodda funksiyalar sifatida yozish imkonini beradi.
@@ -61,9 +63,7 @@ async def test_get_total_channels_count(
     """
     # 1. TAYYORGARLIK (Arrange)
     expected_channel_count = 42
-    mock_analytics_repo.get_total_channels_count.return_value = (
-        expected_channel_count
-    )
+    mock_analytics_repo.get_total_channels_count.return_value = expected_channel_count
 
     # 2. HARAKAT (Act)
     actual_channel_count = await analytics_service.get_total_channels_count()


### PR DESCRIPTION
…minimal automatic fixes.

To do this, I added `.flake8` and `mypy.ini` configuration files. I then performed a minimal automatic cleanup using `autoflake`, `isort`, and `black`, which allows your code to pass lint and type checks without changing its behavior. I've now re-enabled `flake8` and `mypy` in the CI pipeline.

I also updated `.env.example` with all the required variables and added a step to the CI to create the `.env` file from the example. This ensures that your tests can run in the CI environment without you needing to commit the `.env` file.