### PR TITLE
ci: add runtime scans and artifacts

### DIFF
--- a/.github/workflows/compose-verify.yml
+++ b/.github/workflows/compose-verify.yml
@@ -39,6 +39,19 @@ jobs:
       - name: Build & start (Compose)
         run: docker compose -f docker-compose.yml -f .github/ci.compose.override.yml up -d --build
 
+      - name: Trivy scan API image
+        run: |
+          set -e
+          api_img=$(docker compose images -q api)
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+          trivy image --exit-code 1 --ignore-unfixed --severity CRITICAL,HIGH "$api_img"
+
+      - name: Verify required DB columns (drift smoke)
+        run: |
+          set -e
+          q="SELECT table_name,column_name FROM information_schema.columns WHERE table_schema='public' AND table_name IN ('plans','users','channels','scheduled_posts','sent_posts') ORDER BY table_name,column_name;"
+          docker compose exec -T postgres psql -U analytic -d analytic_bot -c "$q"
+
       - name: Verify DB schema (psql)
         run: |
           set -e
@@ -77,6 +90,17 @@ jobs:
             sleep 3
           done
           echo "API not ready in time"; exit 1
+
+      - name: Collect compose logs
+        if: always()
+        run: docker compose logs --no-color > compose.log || true
+
+      - name: Upload compose logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compose-logs
+          path: compose.log
 
       - name: Show container status
         if: always()

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -109,6 +109,34 @@ jobs:
       - name: Run type checking with mypy
         run: poetry run mypy --install-types --non-interactive .
 
+      - name: Generate OpenAPI (fallback to health_app)
+        run: |
+          python - <<'PY'
+          import json, importlib
+          try:
+              api = importlib.import_module("api")
+              app = getattr(api, "app", None)
+              if app is None:
+                  raise ImportError("api.app not found")
+          except Exception:
+              health = importlib.import_module("health_app")
+              app = health.app
+          with open("openapi.json","w") as f:
+              json.dump(app.openapi(), f, indent=2)
+          print("openapi.json written")
+          PY
+
+      - name: Validate OpenAPI
+        run: |
+          pipx install openapi-spec-validator
+          openapi-spec-validator openapi.json
+
+      - name: Upload OpenAPI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi
+          path: openapi.json
+
       - name: Run import sorting check with isort
         run: poetry run isort --check .
 


### PR DESCRIPTION
- In compose-verify, add Trivy image scan for the API container.
- Add a DB drift smoke test to check for required columns.
- Always upload compose logs as an artifact.
- In python-tests, generate and validate an OpenAPI spec, with a fallback to health_app.
- Upload the OpenAPI spec as an artifact.