### PR TITLE
Potential fix for code scanning alert no. 290: Log Injection

### DIFF
--- a/apis/security_api.py
+++ b/apis/security_api.py
@@ -20,6 +20,15 @@ from typing import Optional, Dict, Any
 import logging
 import uvicorn
 
+
+def sanitize_log_input(value: str) -> str:
+    """
+    Remove newline and carriage return characters from log input.
+    """
+    if not isinstance(value, str):
+        value = str(value)
+    return value.replace('\r\n', '').replace('\n', '').replace('\r', '')
+
 # Import security modules
 from security.auth import SecurityManager, get_current_user, require_role
 from security.models import (
@@ -570,7 +579,9 @@ async def update_user_role(
         # Clear user's permission cache
         rbac_manager.clear_user_permissions_cache(user_id)
         
-        logger.info(f"User {user_id} role updated to {new_role.value} by admin {current_user['username']}")
+        safe_user_id = sanitize_log_input(user_id)
+        safe_admin_username = sanitize_log_input(current_user['username'])
+        logger.info(f"User {safe_user_id} role updated to {new_role.value} by admin {safe_admin_username}")
         
         return {"message": f"User role updated to {new_role.value}"}
         


### PR DESCRIPTION
Potential fix for [https://github.com/AlonurKomilov/analyticbot/security/code-scanning/290](https://github.com/AlonurKomilov/analyticbot/security/code-scanning/290)

To fix the log injection vulnerability, we should sanitize any user-provided values before logging them. Specifically, we should remove or replace newline characters (`\n`, `\r`, `\r\n`) from `user_id` and `current_user['username']` before including them in log messages. The best way is to define a helper function (e.g., `sanitize_log_input`) that strips or replaces these characters, and use it to sanitize both `user_id` and `current_user['username']` before logging. This change should be made in the `/security/admin/users/{user_id}/role` endpoint, specifically on line 573. The helper function should be defined in the same file, above its first use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
